### PR TITLE
Bump Microsoft.AspNetCore.Authentication.JwtBearer from 8.0.15 to 8.0.22

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.15" />    
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
 
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.12" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.10" />


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Authentication.JwtBearer dependency-version: 8.0.22 dependency-type: direct:production update-type: version-update:semver-patch ...